### PR TITLE
fix(bug): 解决`GET` 任务中挑战者驱动切换失败的问题

### DIFF
--- a/src/services/bricklayer/bricklayer.py
+++ b/src/services/bricklayer/bricklayer.py
@@ -244,7 +244,7 @@ class Bricklayer(AwesomeFreeMan):
             return self.get_free_game(
                 page_link=page_link,
                 ctx_cookies=ctx_cookies,
-                challenge=challenge
+                challenge=True
             )
         except PaymentException as e:
             logger.debug(ToolBox.runtime_report(


### PR DESCRIPTION
更新